### PR TITLE
Support symlinked profile paths

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ download_bf() {
 }
 
 function check_profile() {
-	FF_USER_DIRECTORY="$(find "${HOME}/.mozilla/firefox/" -maxdepth 1 -type d -regextype egrep -regex '.*[a-zA-Z0-9]+.'${1})" 
+	FF_USER_DIRECTORY="$(find "${HOME}/.mozilla/firefox/" -maxdepth 1 -type d,l -regextype egrep -regex '.*[a-zA-Z0-9]+.'${1})" 
 }
 
 function print_help() {


### PR DESCRIPTION
My FF profile path is actually a symlink not a directory, therefore `find -t d` could not detect it. Adding `,l` to look at symlinks as well fixes the issue.