### PR TITLE
Changed urlbar-background transparency for solid

### DIFF
--- a/colors/blurred.css
+++ b/colors/blurred.css
@@ -20,6 +20,7 @@
 	--bf-urlbar-font-weight: 500;
 	--bf-urlbar-switch-tab-color: #6498EF;
 	--bf-urlbar-bookmark-color: #53E2AE;
+	--bf-urlbar-display: initial;
 	
 	--bf-navbar-padding: 6px;
 	

--- a/colors/solid.css
+++ b/colors/solid.css
@@ -20,7 +20,8 @@
 	--bf-urlbar-font-weight: 500;
 	--bf-urlbar-switch-tab-color: #6498EF;
 	--bf-urlbar-bookmark-color: #53E2AE;
-	
+	--bf-urlbar-display: none;
+
 	--bf-navbar-padding: 6px;
 	
 	--bf-tab-selected-bg: #77777788;

--- a/parts/urlbar.css
+++ b/parts/urlbar.css
@@ -89,7 +89,7 @@ URL bar
 
 #urlbar[breakout-extend="true"]:not([open="true"]) > #urlbar-background {
 	box-shadow: none !important;
-	display: none !important;
+	display: var(--bf-urlbar-display) !important;
 	-moz-appearance: var(--bf-moz-appearance) !important;
 }
 


### PR DESCRIPTION
Urlbar was completely transparent in the solid color version. Changed urlbar-background display to different variable for solid and blurred. Blurred behavior unchanged, Solid now displays full background for urlbar dropdown.